### PR TITLE
Add new exchange wayex

### DIFF
--- a/src/app/api/exchange/withdrawal-fee/route.ts
+++ b/src/app/api/exchange/withdrawal-fee/route.ts
@@ -668,6 +668,8 @@ export async function GET(request: NextRequest) {
             fees = getCoinstashFee(currency)
         } else if (exchange === 'swyftx' && currency) {
             fees = getSwyftxFee(currency)
+        } else if (exchange === 'wayex') {
+            fees = await getWayexFee()
         } else {
             // Get withdrawal fees for other exchanges, fallback to default if not found
             const exchangeFees = withdrawalFees[exchange as keyof typeof withdrawalFees] ?? {}
@@ -793,6 +795,36 @@ async function getOKXFee(): Promise<Record<string, number>> {
     return fees
 }
 
+async function getWayexFee(): Promise<Record<string, number>> {
+    // TODO: Replace with actual WayEx API endpoint when available
+    // Mock implementation - replace with real API call
+    try {
+        const response = await fetch('https://api.wayex.com/v1/withdrawal-fees', {
+            next: { revalidate }, // Cache for 24 hours
+        })
+
+        if (!response.ok) {
+            throw new Error(`WayEx API error: ${response.status}`)
+        }
+
+        const data = await response.json()
+
+        // TODO: Transform the response based on actual API format
+        // This is a placeholder structure
+        const fees: Record<string, number> = {}
+        
+        // Example transformation (adjust based on actual API response):
+        // data.forEach((item: { currency: string; fee: number }) => {
+        //     fees[item.currency] = item.fee
+        // })
+
+        return fees
+    } catch (error) {
+        console.error('Error fetching WayEx fees:', error)
+        return {}
+    }
+}
+
 // use binance as proxy for coinspot
 // async function getCoinspotFee(): Promise<Record<string, number>> {
 //     const exchange = new binance({
@@ -881,4 +913,6 @@ const exchangeFeeType = {
     day1x: 'free',
     bitaroo: 'static',
     hardblock: 'static',
+    // TODO: Update wayex fee type once API is integrated ('dynamic', 'static', or 'free')
+    wayex: 'dynamic',
 }

--- a/src/app/api/exchange/withdrawal-fee/route.ts
+++ b/src/app/api/exchange/withdrawal-fee/route.ts
@@ -668,8 +668,8 @@ export async function GET(request: NextRequest) {
             fees = getCoinstashFee(currency)
         } else if (exchange === 'swyftx' && currency) {
             fees = getSwyftxFee(currency)
-        } else if (exchange === 'wayex') {
-            fees = await getWayexFee()
+            // } else if (exchange === 'wayex') {
+            // fees = await getWayexFee()
         } else {
             // Get withdrawal fees for other exchanges, fallback to default if not found
             const exchangeFees = withdrawalFees[exchange as keyof typeof withdrawalFees] ?? {}
@@ -795,36 +795,6 @@ async function getOKXFee(): Promise<Record<string, number>> {
     return fees
 }
 
-async function getWayexFee(): Promise<Record<string, number>> {
-    // TODO: Replace with actual WayEx API endpoint when available
-    // Mock implementation - replace with real API call
-    try {
-        const response = await fetch('https://api.wayex.com/v1/withdrawal-fees', {
-            next: { revalidate }, // Cache for 24 hours
-        })
-
-        if (!response.ok) {
-            throw new Error(`WayEx API error: ${response.status}`)
-        }
-
-        const data = await response.json()
-
-        // TODO: Transform the response based on actual API format
-        // This is a placeholder structure
-        const fees: Record<string, number> = {}
-        
-        // Example transformation (adjust based on actual API response):
-        // data.forEach((item: { currency: string; fee: number }) => {
-        //     fees[item.currency] = item.fee
-        // })
-
-        return fees
-    } catch (error) {
-        console.error('Error fetching WayEx fees:', error)
-        return {}
-    }
-}
-
 // use binance as proxy for coinspot
 // async function getCoinspotFee(): Promise<Record<string, number>> {
 //     const exchange = new binance({
@@ -874,7 +844,7 @@ async function getLunoFee({ currency }: { currency: string }) {
     )
     const data = await response.json()
 
-    return { [currency]: data.fee }
+    return { [currency]: Number(data.fee) }
 }
 
 async function getDigitalSurgeFee(): Promise<Record<string, number>> {
@@ -914,5 +884,5 @@ const exchangeFeeType = {
     bitaroo: 'static',
     hardblock: 'static',
     // TODO: Update wayex fee type once API is integrated ('dynamic', 'static', or 'free')
-    wayex: 'dynamic',
+    // wayex: 'dynamic',
 }

--- a/src/app/api/price-query/route.ts
+++ b/src/app/api/price-query/route.ts
@@ -37,6 +37,7 @@ const supportedExchanges = [
     'okx',
     'hardblock',
     'day1x',
+    'wayex',
     // 'elbaite',
 ]
 
@@ -149,6 +150,24 @@ const getDay1xOrderBook = async (base: string, quote: string) => {
     }
 
     const json: D1OrderBookResponse = await res.json()
+    return parseD1OrderBook(json)
+}
+
+const getWayexOrderBook = async (base: string, quote: string) => {
+    // TODO: Replace with actual WayEx API endpoint when available
+    // Mock URL structure based on common exchange API patterns
+    const res = await fetch(`https://api.wayex.com/v1/orderbook/${base}-${quote}`)
+
+    if (!res.ok) {
+        if (res.status === 404) {
+            throw new MarketNotFoundError(`${base}/${quote}`, 'wayex')
+        }
+        throw new Error(res.statusText)
+    }
+
+    // TODO: Update response type based on actual API documentation
+    const json: D1OrderBookResponse = await res.json()
+    // TODO: Create custom parser if WayEx API response format differs from D1
     return parseD1OrderBook(json)
 }
 
@@ -345,6 +364,7 @@ const orderbookMethods: Record<
     okx: getOkxOrderBook,
     hardblock: getHardblockMockOrderBook,
     day1x: getDay1xOrderBook,
+    wayex: getWayexOrderBook,
     // elbaite: getElbaiteMockOrderBook,
 }
 

--- a/src/components/FeesChart.tsx
+++ b/src/components/FeesChart.tsx
@@ -136,6 +136,13 @@ const okx = [
     [1_500_000_001, 0.02],
 ]
 
+// TODO: Update with actual WayEx fee tiers when available
+const wayex = [
+    [0, 0.2],
+    [100_000, 0.15],
+    [500_000, 0.1],
+]
+
 function fillDataPoints(dataMap: Record<string, Record<string, number>>, data: number[][], key: string) {
     for (const i of data) {
         if (i[0] !== undefined && i[1] !== undefined) {
@@ -159,6 +166,7 @@ fillDataPoints(dataMap, sx, 'Swyftx')
 fillDataPoints(dataMap, cstash, 'Coinstash')
 fillDataPoints(dataMap, ctree, 'Cointree')
 fillDataPoints(dataMap, okx, 'OKX')
+fillDataPoints(dataMap, wayex, 'WayEx')
 
 const data: any[] = []
 let prev: any
@@ -222,6 +230,13 @@ const allLabels = [
         key: 'OKX',
         colour: '#fff',
         gradientKey: 'okx-gradient',
+        gradientStop: '35%',
+    },
+    {
+        exchange: 'wayex',
+        key: 'WayEx',
+        colour: '#00d4aa',
+        gradientKey: 'wayex-gradient',
         gradientStop: '35%',
     },
 ]

--- a/src/components/FeesChart.tsx
+++ b/src/components/FeesChart.tsx
@@ -136,7 +136,7 @@ const okx = [
     [1_500_000_001, 0.02],
 ]
 
-// TODO: Update with actual WayEx fee tiers when available
+// TODO: Update with actual Wayex fee tiers when available
 const wayex = [
     [0, 0.2],
     [100_000, 0.15],
@@ -166,7 +166,7 @@ fillDataPoints(dataMap, sx, 'Swyftx')
 fillDataPoints(dataMap, cstash, 'Coinstash')
 fillDataPoints(dataMap, ctree, 'Cointree')
 fillDataPoints(dataMap, okx, 'OKX')
-fillDataPoints(dataMap, wayex, 'WayEx')
+fillDataPoints(dataMap, wayex, 'Wayex')
 
 const data: any[] = []
 let prev: any
@@ -234,7 +234,7 @@ const allLabels = [
     },
     {
         exchange: 'wayex',
-        key: 'WayEx',
+        key: 'Wayex',
         colour: '#00d4aa',
         gradientKey: 'wayex-gradient',
         gradientStop: '35%',

--- a/src/components/PriceLookup.tsx
+++ b/src/components/PriceLookup.tsx
@@ -53,10 +53,10 @@ type PriceQueryResult = {
 
 const quickSelectCoins = ['BTC', 'ETH', 'SOL', 'USDC', 'USDT']
 
-const DAY1X_BANNER_KEY = 'day1x-banner-state'
+const WAYEX_BANNER_KEY = 'wayex-banner-state'
 const BANNER_EXPIRY_DAYS = 7
 
-type Day1xBannerState = {
+type WayexBannerState = {
     dismissed: boolean
     firstView: string | null
 }
@@ -155,7 +155,7 @@ const PriceLookup = () => {
         LocalStorageKeys.EnabledExchanges,
         defaultEnabledExchanges
     )
-    const [day1xBannerState, setDay1xBannerState] = useLocalStorage<Day1xBannerState>(DAY1X_BANNER_KEY, {
+    const [wayexBannerState, setWayexBannerState] = useLocalStorage<WayexBannerState>(WAYEX_BANNER_KEY, {
         dismissed: false,
         firstView: null,
     })
@@ -443,26 +443,26 @@ const PriceLookup = () => {
     const submitDisabled = useMemo(() => !localAmount || !localCoin || isLoading, [localAmount, localCoin, isLoading])
 
     // Check if banner should be shown
-    const showDay1xBanner = useMemo(() => {
-        if (day1xBannerState.dismissed) return false
+    const showWayexBanner = useMemo(() => {
+        if (wayexBannerState.dismissed) return false
 
-        if (!day1xBannerState.firstView) {
+        if (!wayexBannerState.firstView) {
             // First time viewing - set the timestamp
-            setDay1xBannerState((prev) => ({
+            setWayexBannerState((prev) => ({
                 ...prev,
                 firstView: new Date().toISOString(),
             }))
             return true
         }
 
-        // Check if a week has passed since first view and if date is before June 1 2025
-        const daysSinceFirstView = differenceInDays(new Date(), new Date(day1xBannerState.firstView))
-        const isBeforeJune2025 = new Date() < new Date('2025-06-01')
-        return daysSinceFirstView < BANNER_EXPIRY_DAYS && isBeforeJune2025
-    }, [day1xBannerState])
+        // Check if a week has passed since first view and if date is before November 1 2025
+        const daysSinceFirstView = differenceInDays(new Date(), new Date(wayexBannerState.firstView))
+        const isBeforeNovember2025 = new Date() < new Date('2025-11-01')
+        return daysSinceFirstView < BANNER_EXPIRY_DAYS && isBeforeNovember2025
+    }, [wayexBannerState])
 
     const handleDismissBanner = () => {
-        setDay1xBannerState((prev) => ({
+        setWayexBannerState((prev) => ({
             ...prev,
             dismissed: true,
         }))
@@ -470,15 +470,15 @@ const PriceLookup = () => {
 
     return (
         <>
-            {showDay1xBanner && (
+            {showWayexBanner && (
                 <div className="relative z-20 w-full space-x-2 bg-linear-to-r from-blue-500 via-blue-300 to-blue-500 px-4 py-2 text-center text-sm sm:text-base dark:from-blue-800 dark:via-blue-500 dark:to-blue-800">
                     <a
-                        href={getExchangeUrl('day1x')}
+                        href={getExchangeUrl('wayex')}
                         target="_blank"
                         className="inline-flex cursor-pointer items-center hover:underline"
                     >
                         🎉 New Exchange{' '}
-                        <ExchangeIcon exchange="day1x" withLabel className="mx-1 px-1" labelClassName="font-bold" /> has
+                        <ExchangeIcon exchange="wayex" withLabel className="mx-1 px-1" labelClassName="font-bold" /> has
                         been added!{' '}
                     </a>
                     <button

--- a/src/components/fee-params.tsx
+++ b/src/components/fee-params.tsx
@@ -8,13 +8,13 @@ import { round } from 'lodash'
 import { Button } from '@/components/ui/button'
 import { defaultExchangeFees, formatExchangeName } from '@/lib/utils'
 import { useLocalStorage } from '@uidotdev/usehooks'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Credenza, CredenzaContent, CredenzaTrigger, CredenzaBody } from '@/components/Credenza'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { LocalStorageKeys } from '@/lib/constants'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import ExchangeIcon from '@/components/ExchangeIcon'
 import posthog from 'posthog-js'
+import { ScrollArea } from '@radix-ui/react-scroll-area'
 
 export function FeeParams() {
     const [open, setOpen] = useState(false)
@@ -40,69 +40,68 @@ export function FeeParams() {
     }, [open])
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
-            <PopoverTrigger asChild>
+        <Credenza open={open} onOpenChange={setOpen}>
+            <CredenzaTrigger asChild>
                 <Button variant="outline" size="icon" className={'bg-transparent'}>
                     <Settings2 className="size-[1.2rem]" />
                 </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-64" onOpenAutoFocus={(e) => e.preventDefault()}>
-                <div className={'absolute right-2 top-2 flex gap-2'}>
-                    <TooltipProvider>
-                        <Tooltip delayDuration={0}>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    size="size-4"
-                                    className={'bg-transparent'}
-                                    aria-label="Reset fees to default"
-                                    onClick={() => setFees(defaultExchangeFees)}
-                                >
-                                    <RotateCcw className="size-4" />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p>Reset to default</p>
-                            </TooltipContent>
-                        </Tooltip>
-                    </TooltipProvider>
-                </div>
-                <div className="grid gap-4">
-                    <div className="space-y-2">
-                        <h4 className="font-medium leading-none">Exchange Fees</h4>
-                        <p className="text-muted-foreground text-sm">Set your own fees if you are on a better tier.</p>
-                    </div>
-                    <div className="grid gap-2">
-                        {Object.entries(fees).map(([exchange, fee]) => (
-                            <div key={exchange + '-fee-input-key'} className="grid grid-cols-9 items-center gap-4">
-                                <Label
-                                    htmlFor={exchange + '-fee-input'}
-                                    className={'col-span-5 flex items-center justify-start gap-2'}
-                                >
-                                    <ExchangeIcon exchange={exchange} />
-                                    {formatExchangeName(exchange)}
-                                </Label>
-                                <div className={'col-span-4 flex items-center'}>
-                                    <Input
-                                        id={exchange + '-fee-input'}
-                                        type={'number'}
-                                        pattern={'(^\\.*)+(^0*)+^\\d+(\\.\\d+)?'}
-                                        className="h-8"
-                                        value={round(fee * 100, 2)}
-                                        onChange={(e) =>
-                                            setFees((prev) => ({
-                                                ...prev,
-                                                [exchange]: round(Number(e.target.value) / 100, 4),
-                                            }))
-                                        }
-                                    />
-                                    <Label className={'pointer-events-none -ml-10 px-3'}>%</Label>
-                                </div>
+            </CredenzaTrigger>
+            <CredenzaContent className="w-full max-w-md" onOpenAutoFocus={(e) => e.preventDefault()}>
+                <ScrollArea className="overflow-y-auto">
+                    <CredenzaBody>
+                        <div className="grid gap-4">
+                            <div className="space-y-2">
+                                <h4 className="font-medium leading-none">Exchange Fees</h4>
+                                <p className="text-muted-foreground text-sm">
+                                    Set your own fees if you are on a better tier.
+                                </p>
                             </div>
-                        ))}
-                    </div>
-                </div>
-            </PopoverContent>
-        </Popover>
+                            <div className="grid gap-2">
+                                {Object.entries(fees).map(([exchange, fee]) => (
+                                    <div
+                                        key={exchange + '-fee-input-key'}
+                                        className="grid grid-cols-9 items-center gap-4"
+                                    >
+                                        <Label
+                                            htmlFor={exchange + '-fee-input'}
+                                            className={'col-span-5 flex items-center justify-start gap-2'}
+                                        >
+                                            <ExchangeIcon exchange={exchange} />
+                                            {formatExchangeName(exchange)}
+                                        </Label>
+                                        <div className={'col-span-4 flex items-center'}>
+                                            <Input
+                                                id={exchange + '-fee-input'}
+                                                type={'number'}
+                                                pattern={'(^\\.*)+(^0*)+^\\d+(\\.\\d+)?'}
+                                                className="h-8"
+                                                value={round(fee * 100, 2)}
+                                                onChange={(e) =>
+                                                    setFees((prev) => ({
+                                                        ...prev,
+                                                        [exchange]: round(Number(e.target.value) / 100, 4),
+                                                    }))
+                                                }
+                                            />
+                                            <Label className={'pointer-events-none -ml-10 px-3'}>%</Label>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <Button
+                            variant="outline"
+                            className={'bg-transparent w-full gap-2 mt-4'}
+                            aria-label="Reset fees to default"
+                            onClick={() => setFees(defaultExchangeFees)}
+                        >
+                            <RotateCcw className="size-4" />
+                            Reset to default
+                        </Button>
+                    </CredenzaBody>
+                </ScrollArea>
+            </CredenzaContent>
+        </Credenza>
     )
 }

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,133 +1,106 @@
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import * as React from 'react'
+import { Drawer as DrawerPrimitive } from 'vaul'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Drawer({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+    return <DrawerPrimitive.Root data-slot="drawer" {...props} />
 }
 
-function DrawerTrigger({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
-  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+    return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
-  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+    return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
-  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+    return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
 }
 
-function DrawerOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
-  return (
-    <DrawerPrimitive.Overlay
-      data-slot="drawer-overlay"
-      className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
-      )}
-      {...props}
-    />
-  )
+function DrawerOverlay({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+    return (
+        <DrawerPrimitive.Overlay
+            data-slot="drawer-overlay"
+            className={cn(
+                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+                className
+            )}
+            {...props}
+        />
+    )
 }
 
-function DrawerContent({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
-  return (
-    <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
-          className
-        )}
-        {...props}
-      >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {children}
-      </DrawerPrimitive.Content>
-    </DrawerPortal>
-  )
+function DrawerContent({ className, children, ...props }: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+    return (
+        <DrawerPortal data-slot="drawer-portal">
+            <DrawerOverlay />
+            <DrawerPrimitive.Content
+                className={cn(
+                    'group/drawer-content fixed z-50 flex h-auto w-screen flex-col bg-background',
+                    'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg',
+                    'bottom-0 data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg',
+                    'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:sm:max-w-sm',
+                    'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:sm:max-w-sm',
+                    className
+                )}
+                data-slot="drawer-content"
+                {...props}
+            >
+                <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+                {children}
+            </DrawerPrimitive.Content>
+        </DrawerPortal>
+    )
 }
 
-function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="drawer-header"
-      className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
-        className
-      )}
-      {...props}
-    />
-  )
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+    return (
+        <div
+            data-slot="drawer-header"
+            className={cn(
+                'flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left',
+                className
+            )}
+            {...props}
+        />
+    )
 }
 
-function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="drawer-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
-      {...props}
-    />
-  )
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+    return <div data-slot="drawer-footer" className={cn('mt-auto flex flex-col gap-2 p-4', className)} {...props} />
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
-  return (
-    <DrawerPrimitive.Title
-      data-slot="drawer-title"
-      className={cn("text-foreground font-semibold", className)}
-      {...props}
-    />
-  )
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+    return (
+        <DrawerPrimitive.Title
+            data-slot="drawer-title"
+            className={cn('text-foreground font-semibold', className)}
+            {...props}
+        />
+    )
 }
 
-function DrawerDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
-  return (
-    <DrawerPrimitive.Description
-      data-slot="drawer-description"
-      className={cn("text-muted-foreground text-sm", className)}
-      {...props}
-    />
-  )
+function DrawerDescription({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+    return (
+        <DrawerPrimitive.Description
+            data-slot="drawer-description"
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    )
 }
 
 export {
-  Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
-  DrawerClose,
-  DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
-  DrawerDescription,
+    Drawer,
+    DrawerPortal,
+    DrawerOverlay,
+    DrawerTrigger,
+    DrawerClose,
+    DrawerContent,
+    DrawerHeader,
+    DrawerFooter,
+    DrawerTitle,
+    DrawerDescription,
 }

--- a/src/exchange-config.ts
+++ b/src/exchange-config.ts
@@ -17,6 +17,7 @@ const EXCHANGE_URLS: Record<string, string> = {
     okx: 'https://www.okx.com',
     hardblock: 'https://www.hardblock.com.au',
     day1x: 'https://www.day1x.io',
+    wayex: 'https://www.wayex.com',
     // elbaite: 'https://www.elbaite.com',
 }
 const ALT_EXCHANGE_URLS: Record<string, string> = {
@@ -43,4 +44,5 @@ export const EXCHANGE_COLOUR: Record<string, string> = {
     liquid: '#0055ff',
     luno: '#0091ff',
     day1x: '#1943c3',
+    wayex: '#00d4aa',
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -79,8 +79,7 @@ const affiliateUrl = (exchange: string, base: string, quote: string) => {
         case 'day1x':
             return `https://day1x.io/?refcode=83277`
         case 'wayex':
-            // TODO: Add affiliate URL when available
-            return undefined
+            return 'https://my.wayex.com/sign-up?aff=SIMONB'
         default:
             return undefined
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,6 +36,8 @@ const tradeUrl = (exchange: string, base: string, quote: string) => {
             return `https://coinstash.com.au/trade`
         case 'day1x':
             return `https://exchange.day1x.io/exchange`
+        case 'wayex':
+            return `https://www.wayex.com/trade`
         // case 'elbaite':
         //     return 'https://www.elbaite.com/'
         default:
@@ -76,6 +78,9 @@ const affiliateUrl = (exchange: string, base: string, quote: string) => {
             return `https://www.hardblock.com.au/join/2da97d02`
         case 'day1x':
             return `https://day1x.io/?refcode=83277`
+        case 'wayex':
+            // TODO: Add affiliate URL when available
+            return undefined
         default:
             return undefined
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,7 +33,7 @@ const formattedExchangeNames: Record<string, string> = {
     okx: 'OKX',
     hardblock: 'HardBlock',
     day1x: 'Day1x',
-    wayex: 'WayEx',
+    wayex: 'Wayex',
     // elbaite: 'Elbaite',
 }
 
@@ -70,7 +70,7 @@ export const defaultExchangeFees: Record<string, number> = {
     okx: 0.005,
     hardblock: 0,
     day1x: 0.001,
-    wayex: 0.002,
+    wayex: 0.004,
     // elbaite: 0.011,
 }
 export const defaultEnabledExchanges: Record<string, boolean> = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,6 +33,7 @@ const formattedExchangeNames: Record<string, string> = {
     okx: 'OKX',
     hardblock: 'HardBlock',
     day1x: 'Day1x',
+    wayex: 'WayEx',
     // elbaite: 'Elbaite',
 }
 
@@ -51,6 +52,7 @@ export const exchangeTypes: Record<string, 'orderbook' | 'broker'> = {
     okx: 'orderbook',
     hardblock: 'broker',
     day1x: 'orderbook',
+    wayex: 'orderbook',
 }
 
 export const defaultExchangeFees: Record<string, number> = {
@@ -68,6 +70,7 @@ export const defaultExchangeFees: Record<string, number> = {
     okx: 0.005,
     hardblock: 0,
     day1x: 0.001,
+    wayex: 0.002,
     // elbaite: 0.011,
 }
 export const defaultEnabledExchanges: Record<string, boolean> = {
@@ -85,6 +88,7 @@ export const defaultEnabledExchanges: Record<string, boolean> = {
     okx: true,
     hardblock: true,
     day1x: true,
+    wayex: true,
     // elbaite: true,
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,14 @@ export interface D1OrderBookResponse {
     bids: [string, string][]
 }
 
+export interface WayexOrderBookResponse {
+    // AlphaPoint L2 Snapshot returns an array where:
+    // Even indices (0, 2, 4...) are bids
+    // Odd indices (1, 3, 5...) are asks
+    // Each entry is an array of [price, quantity, ...]
+    [index: number]: number[][]
+}
+
 export interface SwOrdersResponse {
     price: string
     total: string


### PR DESCRIPTION
Add WayEx exchange with placeholder API integrations and TODOs.

This PR introduces the WayEx exchange into the system, including its configuration, trade URL, and initial API integration points for order book and withdrawal fees. Mock URLs and `TODO` comments have been added to facilitate full implementation once the actual WayEx API documentation is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e8293d7-1ce6-4bf4-8754-4a1d0a200fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e8293d7-1ce6-4bf4-8754-4a1d0a200fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

